### PR TITLE
Added missing IT L10N in new string at 4e74fa0

### DIFF
--- a/HashCheckTranslations.rc
+++ b/HashCheckTranslations.rc
@@ -526,7 +526,7 @@ STRINGTABLE LANGUAGE LANG_ITALIAN, SUBLANG_NEUTRAL
 	IDS_OPT_ENCODING_UTF16   "Salva usando &UTF-16LE"
 	IDS_OPT_ENCODING_ANSI    "Salva usando &ANSI"
 	IDS_OPT_CHK              "Checksum"
-	IDS_OPT_CHK_ERROR        "Please select at least one checksum"
+	IDS_OPT_CHK_ERROR        "Seleziona almeno un checksum"
 	IDS_OPT_FONT             "Tipo di carattere"
 	IDS_OPT_FONT_CHANGE      "&Cambia..."
 }


### PR DESCRIPTION
That new string has been added here: https://github.com/gurnec/HashCheck/commit/4e74fa03f62a6115f2aa9b6a3f28a6071ccfda8e#diff-f83feafb4d7c7dda0c8c054ba3880b6bL511.

HTH,
Matteo