### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/CHashCheckClassFactory.cpp
+++ b/CHashCheckClassFactory.cpp
@@ -35,10 +35,14 @@ STDMETHODIMP CHashCheckClassFactory::CreateInstance( LPUNKNOWN pUnkOuter, REFIID
 
 	if (pUnkOuter) return(CLASS_E_NOAGGREGATION);
 
-	LPCHASHCHECK lpHashCheck = new CHashCheck;
-	if (lpHashCheck == NULL) return(E_OUTOFMEMORY);
-
-	HRESULT hr = lpHashCheck->QueryInterface(riid, ppv);
-	lpHashCheck->Release();
-	return(hr);
+	try {
+		LPCHASHCHECK lpHashCheck = new CHashCheck;
+		HRESULT hr = lpHashCheck->QueryInterface(riid, ppv);
+		lpHashCheck->Release();
+		return(hr);
+	}
+	catch (std::bad_alloc& ba)
+	{
+		return(E_OUTOFMEMORY);
+	}
 }

--- a/CHashCheckClassFactory.hpp
+++ b/CHashCheckClassFactory.hpp
@@ -10,6 +10,7 @@
 #define __CHASHCHECKCLASSFACTORY_HPP__
 
 #include "globals.h"
+#include <new>
 
 class CHashCheckClassFactory : public IClassFactory
 {

--- a/version.h
+++ b/version.h
@@ -12,10 +12,10 @@
 #define HASHCHECK_NAME_STR "HashCheck Shell Extension"
 
 // Full version: MUST be in the form of major,minor,revision,build
-#define HASHCHECK_VERSION_FULL 2,4,0,55
+#define HASHCHECK_VERSION_FULL 2,4,0,56
 
 // String version: May be any suitable string
-#define HASHCHECK_VERSION_STR "2.4.0.55"
+#define HASHCHECK_VERSION_STR "2.4.0.56"
 
 #ifdef _USRDLL
 // PE version: MUST be in the form of major.minor


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V668](https://www.viva64.com/en/w/v668/) There is no sense in testing the 'lpHashCheck' pointer against null, as the memory was allocated using the 'new' operator. The exception will be generated in the case of memory allocation error. chashcheckclassfactory.cpp 39